### PR TITLE
添加检测 带有async的箭头函数

### DIFF
--- a/rules/ecma2017.js
+++ b/rules/ecma2017.js
@@ -6,11 +6,19 @@ module.exports = {
   },
   create (context) {
     return {
-      'FunctionDeclaration|ArrowFunctionExpression' (node) {
+      FunctionDeclaration (node) {
         if (node.async === true) {
           context.report({
             node,
-            message: 'Using async function or async arrow function is not allowed'
+            message: 'Using async function is not allowed'
+          })
+        }
+      },
+      ArrowFunctionExpression (node) {
+        if (node.async === true) {
+          context.report({
+            node,
+            message: 'Using async arrow function is not allowed'
           })
         }
       },

--- a/rules/ecma2017.js
+++ b/rules/ecma2017.js
@@ -10,7 +10,7 @@ module.exports = {
         if (node.async === true) {
           context.report({
             node,
-            message: 'Using async function is not allowed'
+            message: 'Using async function or async arrow function is not allowed'
           })
         }
       },

--- a/rules/ecma2017.js
+++ b/rules/ecma2017.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   create (context) {
     return {
-      FunctionDeclaration (node) {
+      'FunctionDeclaration|ArrowFunctionExpression' (node) {
         if (node.async === true) {
           context.report({
             node,


### PR DESCRIPTION
如果检测从ecm2015版本开始检测，没有问题，如果只检测 ecm2017，则带有async的箭头函数检测不出来