### PR TITLE
refactor: 分离check函数以便复用逻辑

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,6 @@ function check (file, code, options) {
   return problems
 }
 
-exports.check = check
-
 module.exports = parseCode
+
+module.exports.check = check

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ const acornOpts = { ecmaVersion: 12, silent: true, locations: true }
  * @param output {string} - output path of result log
  * @return {{code: number, msg: string}}
  */
-function parseCode ({ version, esmodule, files, useAllRules, output }) {
+function parseCode (options) {
+  const { version, files, useAllRules } = options
   const esVersion = versionMap[version]
 
   if (!esVersion) {
@@ -28,20 +29,11 @@ function parseCode ({ version, esmodule, files, useAllRules, output }) {
     }
   }
 
-  const resultOutputPath = getLogOutputPath(output)
-
   const globOpts = { nodir: true }
-  const stderr = fs.createWriteStream(resultOutputPath, { flags: 'a', encoding: 'utf-8' })
-  const logger = new console.Console(stderr)
   // const pb = new ProgressBar('检测进度')
   console.log('开始检测文件...')
   let hasProblem = false
-  acornOpts.sourceType = esmodule ? 'module' : 'script'
-  try {
-    fs.writeFileSync(resultOutputPath, '')
-  } catch (e) {
-    console.log(e)
-  }
+
   // const isTerminalRun = files.length > 1
   files.forEach((pattern, index) => {
     const globbedFiles = glob.sync(pattern, globOpts)
@@ -55,93 +47,18 @@ function parseCode ({ version, esmodule, files, useAllRules, output }) {
     globbedFiles.forEach((file, index) => {
       // !isTerminalRun ? pb.render({ completed: index + 1, total: globbedFiles.length }) : null
       const code = fs.readFileSync(file, 'utf8')
-      const sourceCodeAst = acorn.parse(code, acornOpts)
-      const problems = runRules({ ast: sourceCodeAst }, esVersion, useAllRules) || []
-
-      if (problems.length) {
-        let fileHadSourceMap = false
-        let sourceMapConsumer = null
-        let originResult = null
-        try {
-          // TODO 暂时对于 soucemap 的检测目前仅只去查看是否存在，后续补全内联等其它种情况
-          if (fs.existsSync(file + '.map')) {
-            fileHadSourceMap = true
-            const sourceMapCode = fs.readFileSync(file + '.map', 'utf-8')
-            // const fileObj = JSON.parse(sourceMapCode)
-            sourceMapConsumer = new sourceMap.SourceMapConsumer(sourceMapCode)
-          }
-        } catch (e) {
-          console.log('error:', e)
-        }
-        // 如果有问题，则退出值非0
-        problems.forEach((problem) => {
-          /**
-           * {
-              message: 'Using let is not allowed',
-              nodeType: 'VariableDeclaration',
-              endLine: 6,
-              endColumn: 12,
-              startLine: 6,
-              startColumn: 0
-            }
-           */
-          try {
-            if (fileHadSourceMap && sourceMapConsumer) {
-              originResult = sourceMapConsumer.originalPositionFor({
-                line: problem.startLine,
-                column: problem.startColumn
-              })
-            }
-          } catch (e) {
-            console.log('error:', e)
-          }
-
-          if (problem.type === 'warning' && useAllRules) {
-            if (originResult) {
-              logger.log(`WARNING:
-            ${problem.message}
-            at file: ${file}
-            at startLine: ${problem.startLine}
-            at startColumn: ${problem.startColumn}
-            sourcemap parse file: ${originResult.source}
-            sourcemap parse line: ${originResult.line}
-            sourcemap parse column: ${originResult.column}
-            `
-              )
-            } else {
-              logger.log(`WARNING:
-            ${problem.message}
-            at file: ${file}
-            at startLine: ${problem.startLine}
-            at startColumn: ${problem.startColumn}
-            `
-              )
-            }
-          } else {
-            if (originResult) {
-              logger.log(`ERROR:
-            ${problem.message}
-            at file: ${file}
-            at startLine: ${problem.startLine}
-            at startColumn: ${problem.startColumn}
-            sourcemap parse file: ${originResult.source}
-            sourcemap parse line: ${originResult.line}
-            sourcemap parse column: ${originResult.column}
-            `
-              )
-            } else {
-              logger.log(`ERROR:
-            ${problem.message}
-            at file: ${file}
-            at startLine: ${problem.startLine}
-            at startColumn: ${problem.startColumn}
-            `
-              )
-            }
-
-            hasProblem = true
-          }
+      const sourceMap = getSourceMap(file)
+      const problems = check(file, code, {
+        ...options,
+        silent: false,
+        sourceMap
+      })
+      if (
+        problems.find(problem => {
+          return !(problem.type === 'warning' && useAllRules)
         })
+      ) {
+        hasProblem = true
       }
     })
   })
@@ -161,5 +78,116 @@ function parseCode ({ version, esmodule, files, useAllRules, output }) {
     }
   }
 }
+
+function getSourceMap (file) {
+  let sourceMapCode
+  try {
+    // TODO 暂时对于 soucemap 的检测目前仅只去查看是否存在，后续补全内联等其它种情况
+    if (fs.existsSync(file + '.map')) {
+      sourceMapCode = fs.readFileSync(file + '.map', 'utf-8')
+    }
+  } catch (e) {
+    console.log('error:', e)
+  }
+  return sourceMapCode
+}
+
+let logger = null
+function createLogger (output) {
+  if (logger) return logger
+  const resultOutputPath = getLogOutputPath(output)
+  try {
+    fs.writeFileSync(resultOutputPath, '')
+  } catch (e) {
+    console.log(e)
+  }
+  const stderr = fs.createWriteStream(resultOutputPath, {
+    flags: 'a',
+    encoding: 'utf-8'
+  })
+
+  return (logger = new console.Console(stderr))
+}
+
+function check (file, code, options) {
+  acornOpts.sourceType = options.esmodule ? 'module' : 'script'
+  const esVersion = versionMap[options.version]
+  const sourceCodeAst = acorn.parse(code, acornOpts)
+  const problems =
+    runRules({ ast: sourceCodeAst }, esVersion, options.useAllRules) || []
+  if (!options.silent && problems.length) {
+    const logger = createLogger(options.output)
+    let sourceMapConsumer = null
+    let originResult = null
+    if (options.sourceMap) {
+      sourceMapConsumer = new sourceMap.SourceMapConsumer(options.sourceMap)
+    }
+    // 如果有问题，则退出值非0
+    problems.forEach(problem => {
+      /**
+       * {
+          message: 'Using let is not allowed',
+          nodeType: 'VariableDeclaration',
+          endLine: 6,
+          endColumn: 12,
+          startLine: 6,
+          startColumn: 0
+        }
+       */
+      try {
+        if (sourceMapConsumer) {
+          originResult = sourceMapConsumer.originalPositionFor({
+            line: problem.startLine,
+            column: problem.startColumn
+          })
+        }
+      } catch (e) {
+        console.log('error:', e)
+      }
+      if (problem.type === 'warning' && options.useAllRules) {
+        if (originResult) {
+          logger.log(`WARNING:
+          ${problem.message}
+          at file: ${file}
+          at startLine: ${problem.startLine}
+          at startColumn: ${problem.startColumn}
+          sourcemap parse file: ${originResult.source}
+          sourcemap parse line: ${originResult.line}
+          sourcemap parse column: ${originResult.column}
+          `)
+        } else {
+          logger.log(`WARNING:
+          ${problem.message}
+          at file: ${file}
+          at startLine: ${problem.startLine}
+          at startColumn: ${problem.startColumn}
+          `)
+        }
+      } else {
+        if (originResult) {
+          logger.log(`ERROR:
+          ${problem.message}
+          at file: ${file}
+          at startLine: ${problem.startLine}
+          at startColumn: ${problem.startColumn}
+          sourcemap parse file: ${originResult.source}
+          sourcemap parse line: ${originResult.line}
+          sourcemap parse column: ${originResult.column}
+          `)
+        } else {
+          logger.log(`ERROR:
+          ${problem.message}
+          at file: ${file}
+          at startLine: ${problem.startLine}
+          at startColumn: ${problem.startColumn}
+          `)
+        }
+      }
+    })
+  }
+  return problems
+}
+
+exports.check = check
 
 module.exports = parseCode


### PR DESCRIPTION
分离`check`函数，来单独的判断某个代码是否符合检查
`check`函数可以接受除默认`options`外的`slient`以及`sourceMap` 选项
`slient` 为ture可以不输出
`sourceMap` 是源码的map文件